### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,11 +208,11 @@ To contribute to the project, fork it on GitHub and send a pull request, all con
     :target: https://pypi.python.org/pypi/mongo-mail-web
     :alt: License
 
-.. |pypi py_versions| image:: https://pypip.in/py_versions/mongo-mail-web/badge.svg
+.. |pypi py_versions| image:: https://img.shields.io/pypi/pyversions/mongo-mail-web.svg
     :target: https://pypi.python.org/pypi/mongo-mail-web
     :alt: Supported Python versions
 
-.. |pypi dev_status| image:: https://pypip.in/status/mongo-mail-web/badge.svg
+.. |pypi dev_status| image:: https://img.shields.io/pypi/status/mongo-mail-web.svg
     :target: https://pypi.python.org/pypi/mongo-mail-web
     :alt: Development Status
     


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20mongo-mail-web))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `mongo-mail-web`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.